### PR TITLE
Custom key option in keyExtrator function to force component re-render

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -326,9 +326,9 @@ export default class PageList extends PureComponent {
 
     keyExtractor (item, index) {
         if (item.key) {
-			return item.key.toString();
-		 }
-		 return index.toString();  
+            return item.key.toString();
+        }
+            return index.toString();  
     }
 
     renderRow ({ item, index }) {

--- a/src/index.js
+++ b/src/index.js
@@ -325,7 +325,10 @@ export default class PageList extends PureComponent {
     }
 
     keyExtractor (item, index) {
-        return index.toString();
+        if (item.key) {
+			return item.key.toString();
+		 }
+		 return index.toString();  
     }
 
     renderRow ({ item, index }) {


### PR DESCRIPTION

This change will give the user an option to be able to use a custom key that will force component re-render if the key of item is changed.